### PR TITLE
Move Google AdSense script to HTML head section

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,10 @@
     }
     </script>
 
+    <!-- Google AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7231854986385753"
+         crossorigin="anonymous"></script>
+
     <!-- Performance optimized analytics -->
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -105,13 +109,6 @@
         ga.async = true;
         ga.src = 'https://www.googletagmanager.com/gtag/js?id=G-YXQPT1LPT8';
         document.head.appendChild(ga);
-
-        // Load AdSense
-        var ads = document.createElement('script');
-        ads.async = true;
-        ads.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7231854986385753';
-        ads.crossOrigin = 'anonymous';
-        document.head.appendChild(ads);
 
         // Send page view after everything loads
         gtag('event', 'page_view');


### PR DESCRIPTION
## Purpose
The user requested to add the Google AdSense snippet code directly to the index.html file to improve ad loading performance and ensure proper placement in the document head.

## Code changes
- **Added**: Google AdSense script tag directly in the HTML head section with proper async loading and crossorigin attributes
- **Removed**: Dynamic JavaScript loading of AdSense script from the performance analytics section
- **Improved**: AdSense now loads earlier in the page lifecycle by being placed in the static HTML rather than being dynamically injected after page load

The AdSense script is now positioned before the analytics code and will load more efficiently as part of the initial HTML parsing.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/88f42c88f70740e5aeb8c9a4188959c1/spark-verse)

👀 [Preview Link](https://88f42c88f70740e5aeb8c9a4188959c1-spark-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>88f42c88f70740e5aeb8c9a4188959c1</projectId>-->
<!--<branchName>spark-verse</branchName>-->